### PR TITLE
Added support for subtypes

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -5,8 +5,6 @@ var EventEmitter = require('events').EventEmitter
 var serviceName = require('multicast-dns-service-types')
 var txt = require('mdns-txt')
 
-var TLD = '.local'
-
 module.exports = Browser
 
 util.inherits(Browser, EventEmitter)
@@ -30,7 +28,12 @@ function Browser (mdns, opts, onup) {
 
   if (onup) this.on('up', onup)
 
-  this._name = serviceName.stringify(opts.type, opts.protocol || 'tcp') + TLD
+  this._type = opts.type
+  this._name = serviceName.stringify({
+    name: opts.type,
+    protocol: opts.protocol || 'tcp',
+    subtypes: opts.subtypes
+  })
   this._mdns = mdns
   this._onresponse = null
   this.services = []
@@ -43,7 +46,7 @@ Browser.prototype.start = function () {
   var self = this
 
   this._onresponse = function (packet) {
-    var matches = buildServicesFor(self._name, packet)
+    var matches = buildServicesFor(self, packet)
     if (matches.length === 0) return
 
     var exists = {}
@@ -73,12 +76,23 @@ Browser.prototype._addService = function (service) {
   this.emit('up', service)
 }
 
-function buildServicesFor (name, packet) {
+function buildServicesFor (browser, packet) {
   var records = packet.answers.concat(packet.additionals)
-
   return records
     .filter(function (rr) {
-      return rr.name === name && rr.type === 'PTR'
+      // check the type
+      if (rr.type !== 'PTR') {
+        return false
+      }
+
+      // Check for matching type
+      var sn = serviceName.parse(rr.name)
+      if (sn.name !== browser._type) {
+        return false
+      }
+
+      // No match
+      return true
     })
     .map(function (ptr) {
       var service = {
@@ -93,14 +107,14 @@ function buildServicesFor (name, packet) {
           if (rr.type === 'SRV') {
             var parts = rr.name.split('.')
             var name = parts[0]
-            var types = serviceName.parse(parts.slice(1, -1).join('.'))
+            var types = serviceName.parse(parts.join('.'))
             service.name = name
             service.fqdn = rr.name
             service.host = rr.data.target
             service.port = rr.data.port
             service.type = types.name
             service.protocol = types.protocol
-            service.subtypes = types.subtypes
+            service.subtypes = types.subtypes || []
           } else if (rr.type === 'TXT') {
             service.rawTxt = rr.data
             service.txt = txt.decode(rr.data)

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -127,8 +127,6 @@ function announce (server, service) {
   var delay = 1000
   var packet = service._records()
 
-  server.register(packet)
-
   ;(function broadcast () {
     // abort if the service have or is being stopped in the meantime
     if (!service._activated || service._destroyed) return

--- a/lib/service.js
+++ b/lib/service.js
@@ -6,8 +6,6 @@ var EventEmitter = require('events').EventEmitter
 var serviceName = require('multicast-dns-service-types')
 var txt = require('mdns-txt')
 
-var TLD = '.local'
-
 module.exports = Service
 
 util.inherits(Service, EventEmitter)
@@ -19,11 +17,24 @@ function Service (opts) {
 
   this.name = opts.name
   this.protocol = opts.protocol || 'tcp'
-  this.type = serviceName.stringify(opts.type, this.protocol)
+  this.type = opts.type || 'http'
   this.host = opts.host || os.hostname()
+
+  // Sometimes the os reported hostname has the parent name on it
+  if (this.host.indexOf('.') !== -1) {
+    var _parts = this.host.split('.')
+    this.host = _parts[0]
+    this.parentDomain = opts.parentDomain || _parts[1]
+  }
+
   this.port = opts.port
-  this.fqdn = this.name + '.' + this.type + TLD
-  this.subtypes = opts.subtypes || null
+  this.subtypes = opts.subtypes || []
+  this.fqdn = serviceName.stringify({
+    instance: this.name,
+    name: this.type,
+    protocol: this.protocol,
+    parentDomain: this.parentDomain
+  })
   this.txt = opts.txt || null
   this.published = false
 
@@ -34,9 +45,13 @@ Service.prototype._records = function () {
   return [rr_ptr(this), rr_srv(this), rr_txt(this)]
 }
 
-function rr_ptr (service) {
+function rr_ptr (service, subtype) {
   return {
-    name: service.type + TLD,
+    name: serviceName.stringify({
+      name: service.type,
+      protocol: service.protocol,
+      subtypes: service.subtypes
+    }),
     type: 'PTR',
     ttl: 28800,
     data: service.fqdn
@@ -50,7 +65,7 @@ function rr_srv (service) {
     ttl: 120,
     data: {
       port: service.port,
-      target: service.host
+      target: service.host + '.' + service.parentDomain
     }
   }
 }

--- a/test/bonjour.js
+++ b/test/bonjour.js
@@ -78,7 +78,7 @@ test('bonjour.find', function (bonjour, t) {
         setTimeout(function () {
           bonjour.destroy()
           t.end()
-        }, 50)
+        }, 1000)
       }
     })
   })
@@ -113,4 +113,50 @@ test('bonjour.findOne - emitter', function (bonjour, t) {
 
   bonjour.publish({ name: 'Emitter', type: 'test', port: 3000 }).on('up', next())
   bonjour.publish({ name: 'Invalid', type: 'test2', port: 3000 }).on('up', next())
+})
+
+test('bonjour.findOne - subtype', function (bonjour, t) {
+  var next = afterAll(function () {
+    var browser = bonjour.find({ type: 'bar', subtypes: ['sub1'] })
+    browser.on('up', function (s) {
+      t.equal(s.name, 'Foo')
+      t.equal(s.port, 3000)
+      // use timeout in an attempt to make sure the invalid record doesn't
+      // bubble up
+      setTimeout(function () {
+        bonjour.destroy()
+        t.end()
+      }, 2000)
+    })
+  })
+
+  bonjour.publish({ name: 'Foo', type: 'bar', port: 3000, subtypes: ['sub1'] }).on('up', next())
+  bonjour.publish({ name: 'Invalid', type: 'bar', port: 3001, subtypes: ['sub2'] }).on('up', next())
+})
+
+test('bonjour.find - all of subtype', function (bonjour, t) {
+  var next = afterAll(function () {
+    var browser = bonjour.find({ type: 'baz' })
+    var ups = 0
+
+    browser.on('up', function (s) {
+      if (s.name === 'Foo') {
+        t.equal(s.name, 'Foo')
+        t.equal(s.fqdn, 'Foo._baz._tcp.local')
+        t.equal(s.port, 3000)
+      } else if (s.name === 'Bar') {
+        t.equal(s.name, 'Bar')
+        t.equal(s.fqdn, 'Bar._baz._tcp.local')
+        t.equal(s.port, 3001)
+      }
+
+      if (++ups === 2) {
+        bonjour.destroy()
+        t.end()
+      }
+    })
+  })
+
+  bonjour.publish({ name: 'Foo', type: 'baz', port: 3000, subtypes: ['sub1'] }).on('up', next())
+  bonjour.publish({ name: 'Bar', type: 'baz', port: 3001, subtypes: ['sub2'] }).on('up', next())
 })


### PR DESCRIPTION
So this is much bigger than I imagined.  There were quite a few things that changed because I moved the functionality for name parsing and construction more into `multicast-dns-service-types`, which this PR required to run (https://github.com/wesleytodd/multicast-dns-service-types/tree/v2.0.0).

Also, while all of the tests pass, I had to change some of the values in them.  They where all pretty much what looked like internal use only variables.  Let me know if I am mistaken.

I haven't yet tested it with my little project, I will update this when I have, but I figured I would post it to get feedback first.  I can also probably test out your ipp project to for compatibility (hopefully this wont break anything), but might not be able to for a few days.

Let me know what you think!