### PR TITLE
A bare-bones subtypes implementation

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -29,6 +29,7 @@ util.inherits(Browser, EventEmitter)
  */
 function Browser (mdns, opts, onup) {
   if (typeof opts === 'function') return new Browser(mdns, null, opts)
+  var self = this
 
   EventEmitter.call(this)
 
@@ -38,11 +39,21 @@ function Browser (mdns, opts, onup) {
   this._txt = dnsTxt(opts.txt)
 
   if (!opts || !opts.type) {
-    this._name = WILDCARD
+    this._names = [ WILDCARD ]
     this._wildcard = true
   } else {
-    this._name = serviceName.stringify(opts.type, opts.protocol || 'tcp') + TLD
-    if (opts.name) this._name = opts.name + '.' + this._name
+    // When requesting specific subtypes, add those to the name map, else
+    // use the single service type and any optional name prefix.
+    if ((opts.subtypes === undefined) || (opts.subtypes.length === 0)) {
+      this._names = [ serviceName.stringify(opts.type, opts.protocol || 'tcp') + TLD ]
+      if (opts.name) this._name = opts.name + '.' + this._name
+    } else {
+      self._names = []
+      opts.subtypes.forEach(function (subtype) {
+        self._names.push('_' + subtype + '._sub.' +
+          serviceName.stringify(opts.type, opts.protocol || 'tcp') + TLD)
+      })
+    }
     this._wildcard = false
   }
 
@@ -55,19 +66,31 @@ function Browser (mdns, opts, onup) {
 
 Browser.prototype.start = function () {
   if (this._onresponse) return
-
   var self = this
+  var nameMap = {}
+  var nameInMap = function (recordName) {
+    var nameMatch = false
+    self._names.forEach(function (name) {
+      if (name === recordName) {
+        nameMatch = true
+      }
+    })
+    return nameMatch
+  }
 
   // List of names for the browser to listen for. In a normal search this will
   // be the primary name stored on the browser. In case of a wildcard search
   // the names will be determined at runtime as responses come in.
-  var nameMap = {}
-  if (!this._wildcard) nameMap[this._name] = true
+  if (!this._wildcard) {
+    this._names.forEach(function (name) {
+      nameMap[name] = true
+    })
+  }
 
   this._onresponse = function (packet, rinfo) {
     if (self._wildcard) {
       packet.answers.forEach(function (answer) {
-        if (answer.type !== 'PTR' || answer.name !== self._name || answer.name in nameMap) return
+        if (answer.type !== 'PTR' || nameInMap(answer.map) || answer.name in nameMap) return
         nameMap[answer.data] = true
         self._mdns.query(answer.data, 'PTR')
       })
@@ -82,8 +105,27 @@ Browser.prototype.start = function () {
       if (matches.length === 0) return
 
       matches.forEach(function (service) {
-        if (self._serviceMap[service.fqdn]) return // ignore already registered services
-        self._addService(service)
+        var serviceIndex = 0
+        if (self._serviceMap[service.fqdn]) {
+          // ignore already registered services, which exist is the new service
+          // has no subtype
+          if (service.subtypes.length === 0) return
+
+          // Check to see if this includes a subtype that didn't exist previously
+          // If so, add it to the service already cached and emit a CB
+          for (serviceIndex = 0; serviceIndex < self.services.length; serviceIndex += 1) {
+            if (self.services[serviceIndex].fqdn === service.fqdn) {
+              break
+            }
+          }
+          // If the service subtype type already exists in the service, ignore it.
+          if (self.services[serviceIndex].subtypes.indexOf(service.subtypes[0]) !== -1) return
+
+          self.services[serviceIndex].subtypes.push(service.subtypes[0])
+          self.emit('up', self.services[serviceIndex])
+        } else {
+          self._addService(service)
+        }
       })
     })
   }
@@ -100,7 +142,10 @@ Browser.prototype.stop = function () {
 }
 
 Browser.prototype.update = function () {
-  this._mdns.query(this._name, 'PTR')
+  var self = this
+  this._names.forEach(function (name) {
+    self._mdns.query(name, 'PTR')
+  })
 }
 
 Browser.prototype._addService = function (service) {
@@ -166,6 +211,7 @@ function buildServicesFor (name, packet, txt, referer) {
             var parts = rr.name.split('.')
             var name = parts[0]
             var types = serviceName.parse(parts.slice(1, -1).join('.'))
+            var subparts = ptr.name.split('.')
             service.name = name
             service.fqdn = rr.name
             service.host = rr.data.target
@@ -173,7 +219,15 @@ function buildServicesFor (name, packet, txt, referer) {
             service.port = rr.data.port
             service.type = types.name
             service.protocol = types.protocol
-            service.subtypes = types.subtypes
+
+            // If the subparts length is larger than the parts length, then
+            // there does indeed exist a subtype and we add that to the main
+            // service record.
+            if (subparts.length > (parts.length - 1)) {
+              service.subtypes = [ subparts[0].slice(1) ]
+            } else {
+              service.subtypes = []
+            }
           } else if (rr.type === 'TXT') {
             service.rawTxt = rr.data
             service.txt = txt.decode(rr.data)

--- a/lib/service.js
+++ b/lib/service.js
@@ -31,7 +31,13 @@ function Service (opts) {
 }
 
 Service.prototype._records = function () {
-  var records = [rrPtr(this), rrSrv(this), rrTxt(this)]
+  var records = [ rrPtr(this), rrSrv(this), rrTxt(this) ]
+
+  if (this.subtypes) {
+    for (var subtypeIndex = 0; subtypeIndex < this.subtypes.length; subtypeIndex += 1) {
+      records.push(rrPtr(this, subtypeIndex))
+    }
+  }
 
   var self = this
   var interfaces = os.networkInterfaces()
@@ -49,9 +55,10 @@ Service.prototype._records = function () {
   return records
 }
 
-function rrPtr (service) {
+function rrPtr (service, subtypeIndex) {
   return {
-    name: service.type + TLD,
+    name: (subtypeIndex !== undefined) ? '_' + service.subtypes[subtypeIndex] + '._sub.' +
+      service.type + TLD : service.type + TLD,
     type: 'PTR',
     ttl: 28800,
     data: service.fqdn


### PR DESCRIPTION
Hi,

With no disrepect to @wesleytodd, I've made a smaller set of changes to enable sub-type publishing and discovery.

I believe the changes are suitable, and don't rely on any changes outside that of the `bonjour` module. I'm more than happy to discuss this work and how we might go forwards with Wesley's implementation instead if need be, but I required something that worked 'quickly'.

Tests updated and changes have been tested with both OSX's DNS-SD tools and Avahi.

Cheers!

