### PR TITLE
Enhancement: Allow Specification of IP For Service Record

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -5,6 +5,7 @@ var util = require('util')
 var EventEmitter = require('events').EventEmitter
 var serviceName = require('multicast-dns-service-types')
 var txt = require('dns-txt')()
+var net = require('net')
 
 var TLD = '.local'
 
@@ -26,6 +27,11 @@ function Service (opts) {
   this.subtypes = opts.subtypes || null
   this.txt = opts.txt || null
   this.published = false
+  this.ip = (function () {
+    if (net.isIP(opts.ip) === 4) return { family: 'IPv4', ip: opts.ip }
+    if (net.isIP(opts.ip) === 6) return { family: 'IPv6', ip: opts.ip }
+    return false
+  })()
 
   this._activated = false // indicates intent - true: starting/started, false: stopping/stopped
 }
@@ -34,17 +40,22 @@ Service.prototype._records = function () {
   var records = [rrPtr(this), rrSrv(this), rrTxt(this)]
 
   var self = this
-  var interfaces = os.networkInterfaces()
-  Object.keys(interfaces).forEach(function (name) {
-    interfaces[name].forEach(function (addr) {
-      if (addr.internal) return
-      if (addr.family === 'IPv4') {
-        records.push(rrA(self, addr.address))
-      } else {
-        records.push(rrAaaa(self, addr.address))
-      }
+  if (!this.ip) {
+    var interfaces = os.networkInterfaces()
+    Object.keys(interfaces).forEach(function (name) {
+      interfaces[name].forEach(function (addr) {
+        if (addr.internal) return
+        if (addr.family === 'IPv4') {
+          records.push(rrA(self, addr.address))
+        } else {
+          records.push(rrAaaa(self, addr.address))
+        }
+      })
     })
-  })
+  } else {
+    if (this.ip.family === 'IPv4') records.push(rrA(self, this.ip.address))
+    if (this.ip.family === 'IPv6') records.push(rrAaaa(self, this.ip.address))
+  }
 
   return records
 }


### PR DESCRIPTION
This allows you to specify the IP address for the service record versus allowing it to announce all of the interfaces. This will also address Issue #15 as it will allow you to specify a foreign IP address.