### PR TITLE
bug in parsing section when '.'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -163,9 +163,9 @@ function buildServicesFor (name, packet, txt, referer) {
         })
         .forEach(function (rr) {
           if (rr.type === 'SRV') {
-            var parts = rr.name.split('.')
-            var name = parts[0]
-            var types = serviceName.parse(parts.slice(1, -1).join('.'))
+            var parts = rr.name.match(/^(.*)\.(.*)\.(.*)\.(?:local)$/)
+            var name = parts[1]
+            var types = serviceName.parse(parts.slice(2).join('.'))
             service.name = name
             service.fqdn = rr.name
             service.host = rr.data.target

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -5,6 +5,7 @@ var EventEmitter = require('events').EventEmitter
 var serviceName = require('multicast-dns-service-types')
 var dnsEqual = require('dns-equal')
 var dnsTxt = require('dns-txt')
+var LRUMap = require('./lru').LRUMap;
 
 var TLD = '.local'
 var WILDCARD = '_services._dns-sd._udp' + TLD
@@ -34,7 +35,12 @@ function Browser (mdns, opts, onup) {
 
   this._mdns = mdns
   this._onresponse = null
-  this._serviceMap = {}
+  if (opts.maxItems) {
+    this._serviceMap = new LRUMap(opts.maxItems);
+  } else {
+    this._serviceMap = new Map();
+  }
+  
   this._txt = dnsTxt(opts.txt)
 
   if (!opts || !opts.type) {
@@ -46,7 +52,11 @@ function Browser (mdns, opts, onup) {
     this._wildcard = false
   }
 
-  this.services = []
+  Object.defineProperty(this, 'services', {
+    get: function() { 
+      return Array.from(this._serviceMap.values())
+    }
+  })
 
   if (onup) this.on('up', onup)
 
@@ -82,7 +92,7 @@ Browser.prototype.start = function () {
       if (matches.length === 0) return
 
       matches.forEach(function (service) {
-        if (self._serviceMap[service.fqdn]) return // ignore already registered services
+        if (self._serviceMap.has(service.fqdn)) return // ignore already registered services
         self._addService(service)
       })
     })
@@ -104,8 +114,7 @@ Browser.prototype.update = function () {
 }
 
 Browser.prototype._addService = function (service) {
-  this.services.push(service)
-  this._serviceMap[service.fqdn] = true
+  this._serviceMap.set(service.fqdn, service)
   this.emit('up', service)
 }
 
@@ -119,8 +128,7 @@ Browser.prototype._removeService = function (fqdn) {
     }
   })
   if (!service) return
-  this.services.splice(index, 1)
-  delete this._serviceMap[fqdn]
+  this._serviceMap.delete(fqdn)
   this.emit('down', service)
 }
 

--- a/lib/lru.js
+++ b/lib/lru.js
@@ -1,0 +1,305 @@
+/**
+ * A doubly linked list-based Least Recently Used (LRU) cache. Will keep most
+ * recently used items while discarding least recently used items when its limit
+ * is reached.
+ *
+ * Licensed under MIT. Copyright (c) 2010 Rasmus Andersson <http://hunch.se/>
+ * See README.md for details.
+ *
+ * Illustration of the design:
+ *
+ *       entry             entry             entry             entry
+ *       ______            ______            ______            ______
+ *      | head |.newer => |      |.newer => |      |.newer => | tail |
+ *      |  A   |          |  B   |          |  C   |          |  D   |
+ *      |______| <= older.|______| <= older.|______| <= older.|______|
+ *
+ *  removed  <--  <--  <--  <--  <--  <--  <--  <--  <--  <--  <--  added
+ */
+(function(g,f){
+    const e = typeof exports == 'object' ? exports : typeof g == 'object' ? g : {};
+    f(e);
+    if (typeof define == 'function' && define.amd) { define('lru', e); }
+  })(this, function(exports) {
+  
+  const NEWER = Symbol('newer');
+  const OLDER = Symbol('older');
+  
+  function LRUMap(limit, entries) {
+    if (typeof limit !== 'number') {
+      // called as (entries)
+      entries = limit;
+      limit = 0;
+    }
+  
+    this.size = 0;
+    this.limit = limit;
+    this.oldest = this.newest = undefined;
+    this._keymap = new Map();
+  
+    if (entries) {
+      this.assign(entries);
+      if (limit < 1) {
+        this.limit = this.size;
+      }
+    }
+  }
+  
+  exports.LRUMap = LRUMap;
+  
+  function Entry(key, value) {
+    this.key = key;
+    this.value = value;
+    this[NEWER] = undefined;
+    this[OLDER] = undefined;
+  }
+  
+  
+  LRUMap.prototype._markEntryAsUsed = function(entry) {
+    if (entry === this.newest) {
+      // Already the most recenlty used entry, so no need to update the list
+      return;
+    }
+    // HEAD--------------TAIL
+    //   <.older   .newer>
+    //  <--- add direction --
+    //   A  B  C  <D>  E
+    if (entry[NEWER]) {
+      if (entry === this.oldest) {
+        this.oldest = entry[NEWER];
+      }
+      entry[NEWER][OLDER] = entry[OLDER]; // C <-- E.
+    }
+    if (entry[OLDER]) {
+      entry[OLDER][NEWER] = entry[NEWER]; // C. --> E
+    }
+    entry[NEWER] = undefined; // D --x
+    entry[OLDER] = this.newest; // D. --> E
+    if (this.newest) {
+      this.newest[NEWER] = entry; // E. <-- D
+    }
+    this.newest = entry;
+  };
+  
+  LRUMap.prototype.assign = function(entries) {
+    let entry, limit = this.limit || Number.MAX_VALUE;
+    this._keymap.clear();
+    let it = entries[Symbol.iterator]();
+    for (let itv = it.next(); !itv.done; itv = it.next()) {
+      let e = new Entry(itv.value[0], itv.value[1]);
+      this._keymap.set(e.key, e);
+      if (!entry) {
+        this.oldest = e;
+      } else {
+        entry[NEWER] = e;
+        e[OLDER] = entry;
+      }
+      entry = e;
+      if (limit-- == 0) {
+        throw new Error('overflow');
+      }
+    }
+    this.newest = entry;
+    this.size = this._keymap.size;
+  };
+  
+  LRUMap.prototype.get = function(key) {
+    // First, find our cache entry
+    var entry = this._keymap.get(key);
+    if (!entry) return; // Not cached. Sorry.
+    // As <key> was found in the cache, register it as being requested recently
+    this._markEntryAsUsed(entry);
+    return entry.value;
+  };
+  
+  LRUMap.prototype.set = function(key, value) {
+    var entry = this._keymap.get(key);
+  
+    if (entry) {
+      // update existing
+      entry.value = value;
+      this._markEntryAsUsed(entry);
+      return this;
+    }
+  
+    // new entry
+    this._keymap.set(key, (entry = new Entry(key, value)));
+  
+    if (this.newest) {
+      // link previous tail to the new tail (entry)
+      this.newest[NEWER] = entry;
+      entry[OLDER] = this.newest;
+    } else {
+      // we're first in -- yay
+      this.oldest = entry;
+    }
+  
+    // add new entry to the end of the linked list -- it's now the freshest entry.
+    this.newest = entry;
+    ++this.size;
+    if (this.size > this.limit) {
+      // we hit the limit -- remove the head
+      this.shift();
+    }
+  
+    return this;
+  };
+  
+  LRUMap.prototype.shift = function() {
+    // todo: handle special case when limit == 1
+    var entry = this.oldest;
+    if (entry) {
+      if (this.oldest[NEWER]) {
+        // advance the list
+        this.oldest = this.oldest[NEWER];
+        this.oldest[OLDER] = undefined;
+      } else {
+        // the cache is exhausted
+        this.oldest = undefined;
+        this.newest = undefined;
+      }
+      // Remove last strong reference to <entry> and remove links from the purged
+      // entry being returned:
+      entry[NEWER] = entry[OLDER] = undefined;
+      this._keymap.delete(entry.key);
+      --this.size;
+      return [entry.key, entry.value];
+    }
+  };
+  
+  // ----------------------------------------------------------------------------
+  // Following code is optional and can be removed without breaking the core
+  // functionality.
+  
+  LRUMap.prototype.find = function(key) {
+    let e = this._keymap.get(key);
+    return e ? e.value : undefined;
+  };
+  
+  LRUMap.prototype.has = function(key) {
+    return this._keymap.has(key);
+  };
+  
+  LRUMap.prototype['delete'] = function(key) {
+    var entry = this._keymap.get(key);
+    if (!entry) return;
+    this._keymap.delete(entry.key);
+    if (entry[NEWER] && entry[OLDER]) {
+      // relink the older entry with the newer entry
+      entry[OLDER][NEWER] = entry[NEWER];
+      entry[NEWER][OLDER] = entry[OLDER];
+    } else if (entry[NEWER]) {
+      // remove the link to us
+      entry[NEWER][OLDER] = undefined;
+      // link the newer entry to head
+      this.oldest = entry[NEWER];
+    } else if (entry[OLDER]) {
+      // remove the link to us
+      entry[OLDER][NEWER] = undefined;
+      // link the newer entry to head
+      this.newest = entry[OLDER];
+    } else {// if(entry[OLDER] === undefined && entry.newer === undefined) {
+      this.oldest = this.newest = undefined;
+    }
+  
+    this.size--;
+    return entry.value;
+  };
+  
+  LRUMap.prototype.clear = function() {
+    // Not clearing links should be safe, as we don't expose live links to user
+    this.oldest = this.newest = undefined;
+    this.size = 0;
+    this._keymap.clear();
+  };
+  
+  
+  function EntryIterator(oldestEntry) { this.entry = oldestEntry; }
+  EntryIterator.prototype[Symbol.iterator] = function() { return this; }
+  EntryIterator.prototype.next = function() {
+    let ent = this.entry;
+    if (ent) {
+      this.entry = ent[NEWER];
+      return { done: false, value: [ent.key, ent.value] };
+    } else {
+      return { done: true, value: undefined };
+    }
+  };
+  
+  
+  function KeyIterator(oldestEntry) { this.entry = oldestEntry; }
+  KeyIterator.prototype[Symbol.iterator] = function() { return this; }
+  KeyIterator.prototype.next = function() {
+    let ent = this.entry;
+    if (ent) {
+      this.entry = ent[NEWER];
+      return { done: false, value: ent.key };
+    } else {
+      return { done: true, value: undefined };
+    }
+  };
+  
+  function ValueIterator(oldestEntry) { this.entry = oldestEntry; }
+  ValueIterator.prototype[Symbol.iterator] = function() { return this; }
+  ValueIterator.prototype.next = function() {
+    let ent = this.entry;
+    if (ent) {
+      this.entry = ent[NEWER];
+      return { done: false, value: ent.value };
+    } else {
+      return { done: true, value: undefined };
+    }
+  };
+  
+  
+  LRUMap.prototype.keys = function() {
+    return new KeyIterator(this.oldest);
+  };
+  
+  LRUMap.prototype.values = function() {
+    return new ValueIterator(this.oldest);
+  };
+  
+  LRUMap.prototype.entries = function() {
+    return this;
+  };
+  
+  LRUMap.prototype[Symbol.iterator] = function() {
+    return new EntryIterator(this.oldest);
+  };
+  
+  LRUMap.prototype.forEach = function(fun, thisObj) {
+    if (typeof thisObj !== 'object') {
+      thisObj = this;
+    }
+    let entry = this.oldest;
+    while (entry) {
+      fun.call(thisObj, entry.value, entry.key, this);
+      entry = entry[NEWER];
+    }
+  };
+  
+  /** Returns a JSON (array) representation */
+  LRUMap.prototype.toJSON = function() {
+    var s = new Array(this.size), i = 0, entry = this.oldest;
+    while (entry) {
+      s[i++] = { key: entry.key, value: entry.value };
+      entry = entry[NEWER];
+    }
+    return s;
+  };
+  
+  /** Returns a String representation */
+  LRUMap.prototype.toString = function() {
+    var s = '', entry = this.oldest;
+    while (entry) {
+      s += String(entry.key)+':'+entry.value;
+      entry = entry[NEWER];
+      if (entry) {
+        s += ' < ';
+      }
+    }
+    return s;
+  };
+  
+  });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bonjour",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
   "main": "index.js",
   "dependencies": {
@@ -8,7 +8,7 @@
     "deep-equal": "^1.0.1",
     "dns-equal": "^1.0.0",
     "dns-txt": "^2.0.2",
-    "multicast-dns": "^6.0.1",
+    "multicast-dns": "evs-broadcast/multicast-dns#0ee1473",
     "multicast-dns-service-types": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bonjour",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
   "main": "index.js",
   "dependencies": {
@@ -8,7 +8,7 @@
     "deep-equal": "^1.0.1",
     "dns-equal": "^1.0.0",
     "dns-txt": "^2.0.2",
-    "multicast-dns": "evs-broadcast/multicast-dns#0ee1473",
+    "multicast-dns": "^6.2.1",
     "multicast-dns-service-types": "^1.1.0"
   },
   "devDependencies": {

--- a/test/client.js
+++ b/test/client.js
@@ -1,0 +1,4 @@
+var bonjour = require('../')()
+let browser = bonjour.find({ type: 'nmos-node', maxItems: 5 }, function (service) {
+    console.log('Found an nmos-node:', service.fqdn, "#", browser.services.map(s => s.fqdn).join(","));
+}); 


### PR DESCRIPTION
When there are "." (dots) in the name, bonjour can't parse correctly the name and types.
Ex: query_10.193.31.168._nmos-query._tcp.local is parsed as this:
```
{
    "addresses": [],
    "rawTxt": {
        "type": "Buffer",
        "data": [
            22,
            97,
            112,
            105,
            95,
            118,
            101,
            114,
            61,
            118,
            49,
            46,
            48,
            44,
            118,
            49,
            46,
            49,
            44,
            118,
            49,
            46,
            50,
            14,
            97,
            112,
            105,
            95,
            112,
            114,
            111,
            116,
            111,
            61,
            104,
            116,
            116,
            112,
            5,
            112,
            114,
            105,
            61,
            48
        ]
    },
    "txt": {
        "api_ver": "v1.0,v1.1,v1.2",
        "api_proto": "http",
        "pri": "0"
    },
    "name": "query_10",
    "fqdn": "query_10.193.31.168._nmos-query._tcp.local",
    "host": "vmdocker.local",
    "referer": {
        "address": "10.193.31.168",
        "family": "IPv4",
        "port": 5353,
        "size": 289
    },
    "port": 80,
    "type": "193",
    "protocol": "31",
    "subtypes": [
        "168",
        "nmos-query",
        "tcp"
    ]
}
```
