### PR TITLE
Catch error event when multicastdns emit some error

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ bonjour.find({ type: 'http' }, function (service) {
 ### Initializing
 
 ```js
-var bonjour = require('bonjour')([options])
+var bonjour = require('bonjour')([options], [error])
 ```
 
 The `options` are optional and will be used when initializing the
 underlying multicast-dns server. For details see [the multicast-dns
 documentation](https://github.com/mafintosh/multicast-dns#mdns--multicastdnsoptions).
+
+The `error` is the callback when some error occur.
 
 ### Publishing
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The `options` are optional and will be used when initializing the
 underlying multicast-dns server. For details see [the multicast-dns
 documentation](https://github.com/mafintosh/multicast-dns#mdns--multicastdnsoptions).
 
-The `error` is the callback when some error occur.
+The `error` is the callback when some error occurs.
 
 ### Publishing
 

--- a/index.js
+++ b/index.js
@@ -6,9 +6,15 @@ var Browser = require('./lib/browser')
 
 module.exports = Bonjour
 
-function Bonjour (opts) {
-  if (!(this instanceof Bonjour)) return new Bonjour(opts)
-  this._server = new Server(opts)
+function Bonjour (opts, error) {
+  if (!(this instanceof Bonjour)) return new Bonjour(opts, error)
+
+  if (typeof opts === 'function') {
+    error = opts;
+    opts = undefined;
+  }
+
+  this._server = new Server(opts, error)
   this._registry = new Registry(this._server)
 }
 

--- a/lib/mdns-server.js
+++ b/lib/mdns-server.js
@@ -7,11 +7,12 @@ var deepEqual = require('deep-equal')
 
 module.exports = Server
 
-function Server (opts) {
+function Server (opts, error) {
   this.mdns = multicastdns(opts)
   this.mdns.setMaxListeners(0)
   this.registry = {}
   this.mdns.on('query', this._respondToQuery.bind(this))
+  this.mdns.on('error', typeof error === 'function' ? error : console.log)
 }
 
 Server.prototype.register = function (records) {


### PR DESCRIPTION
Used in Electron, there is no way to catch some internal `multicastdns` error, when some error occurs, the main thread is crashed. This PR adds a default error callback when user not provide.