### PR TITLE
CVE-2021-23386: fix vulnerable multicast-dns package

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -175,8 +175,8 @@ function buildServicesFor (name, packet, txt, referer) {
             service.protocol = types.protocol
             service.subtypes = types.subtypes
           } else if (rr.type === 'TXT') {
-            service.rawTxt = rr.data
-            service.txt = txt.decode(rr.data)
+            service.rawTxt = rr.data[0]
+            service.txt = txt.decode(rr.data[0])
           }
         })
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deep-equal": "^1.0.1",
     "dns-equal": "^1.0.0",
     "dns-txt": "^2.0.2",
-    "multicast-dns": "^6.0.1",
+    "multicast-dns": "^7.2.3",
     "multicast-dns-service-types": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR fixes the CVE noted in the title to address: https://github.com/watson/bonjour/issues/63

Based on the tests that exist in the repo updating the major version only required adjusting a few lines in browser.js. After that all tests that broke after updating to `7.2.3` appear to be working correctly again.