### PR TITLE
Allow advertised IP addresses to be specified for each service

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Options are:
 - `protocol` (string, optional) - `udp` or `tcp` (default)
 - `txt` (object, optional) - a key/value object to broadcast as the TXT
   record
+- `addresses` (array, optional) - array of IP addresses to advertise.
+  Array elements are IP address specifications as returned by
+  `os.networkInterfaces()`
 
 IANA maintains a [list of official service types and port
 numbers](http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml).

--- a/lib/service.js
+++ b/lib/service.js
@@ -26,6 +26,7 @@ function Service (opts) {
   this.subtypes = opts.subtypes || null
   this.txt = opts.txt || null
   this.published = false
+  this.addresses = opts.addresses || null
 
   this._activated = false // indicates intent - true: starting/started, false: stopping/stopped
 }
@@ -34,16 +35,14 @@ Service.prototype._records = function () {
   var records = [rrPtr(this), rrSrv(this), rrTxt(this)]
 
   var self = this
-  var interfaces = os.networkInterfaces()
-  Object.keys(interfaces).forEach(function (name) {
-    interfaces[name].forEach(function (addr) {
-      if (addr.internal) return
-      if (addr.family === 'IPv4') {
-        records.push(rrA(self, addr.address))
-      } else {
-        records.push(rrAaaa(self, addr.address))
-      }
-    })
+  var addresses = self.addresses || Object.values(os.networkInterfaces()).flat();
+  addresses.forEach(function (addr) {
+    if (addr.internal) return
+    if (addr.family === 'IPv4') {
+      records.push(rr_a(self, addr.address))
+    } else {
+      records.push(rr_aaaa(self, addr.address))
+    }
   })
 
   return records


### PR DESCRIPTION
As #75 suggests, sometimes irrelevant IP addresses are advertised in response packets. This patch allows the user to tell which addresses to advertise. It is not the optimal solution, but provides some control.